### PR TITLE
Add dot: true to spawnOptions for copying hidden files

### DIFF
--- a/lib/cameron_js.js
+++ b/lib/cameron_js.js
@@ -8,7 +8,8 @@ const spawnOptions = {
   cwd: process.cwd(),
   env: process.env,
   stdio: "inherit",
-  encoding: "utf-8"
+  encoding: "utf-8",
+  dot: true
 };
 const colors = {
   red: "\x1b[31m%s\x1b[0m",


### PR DESCRIPTION
Resolves #1 

With this addition `.gitignore` copies over in its entirety!

`cameronjs new test1`

![image](https://user-images.githubusercontent.com/9841162/96351398-da035d80-106f-11eb-948b-152c72eeb5de.png)
